### PR TITLE
Show help when no args are provided

### DIFF
--- a/efi-roller
+++ b/efi-roller
@@ -264,6 +264,8 @@ Commands:
 EOF
 }
 
+test -z "$@" && help
+
 for cmd in "$@"; do
     case "$cmd" in
         sign)


### PR DESCRIPTION
When no arguments are provided, nothing is returned. Return the help
text instead.